### PR TITLE
Fix undefined method calls in HANAFirewall::MainDialog

### DIFF
--- a/package/yast2-hana-firewall.changes
+++ b/package/yast2-hana-firewall.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct  8 14:45:34 UTC 2020 - Petr Pavlu <petr.pavlu@suse.com>
+
+- Fix undefined method calls in HANAFirewall::MainDialog, such as
+  get_inst_numbers(), by including their definition module
+  HANAFirewall in the MainDialog class. (bsc#1177274)
+- 2.0.4
+
+-------------------------------------------------------------------
 Wed Dec 11 10:46:46 UTC 2019 - Peter Varkoly <varkoly@suse.com>
 
 - bsc#1158843 hana-*: Broken gettext support

--- a/package/yast2-hana-firewall.spec
+++ b/package/yast2-hana-firewall.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-hana-firewall
-Version:        2.0.3
+Version:        2.0.4
 Release:        0
 License:        GPL-3.0
 Summary:        Assign HANA firewall services to zones

--- a/src/lib/hanafirewallui/main_dialog.rb
+++ b/src/lib/hanafirewallui/main_dialog.rb
@@ -46,6 +46,7 @@ module HANAFirewall
     include UIShortcuts
     include I18n
     include Logger
+    include HANAFirewall
 
     def initialize
       textdomain "hanafirewall"


### PR DESCRIPTION
Fix undefined method calls in `HANAFirewall::MainDialog`, such as `get_inst_numbers()`, by including their definition module `HANAFirewall` in the `MainDialog` class (bsc#1177274).

This fixes a problem introduced in f7b207f0e8216593bacf37b2f54cdb529d7eea1a. Code in `src/clients/hanafirewall.rb` previously contained `'include HANAFirewall'` which pulled `HANAFirewall::get_inst_numbers()` to the top level thus making it available everywhere. Updated code no longer does that which made `get_inst_numbers()` unavailable in `HANAFirewall::MainDialog`.

Note: The fix is for the SLE-15-SP2 branch and intended to be merged on master afterwards.